### PR TITLE
Fix a bug where format-time() and parse-time() would be off by two milliseconds.

### DIFF
--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -821,7 +821,7 @@ public class BuiltinFunctions {
 
       try {
         SimpleDateFormat format = new SimpleDateFormat(formatstr);
-        format.setTimeZone(new SimpleTimeZone(SimpleTimeZone.UTC_TIME, "UTC"));
+        format.setTimeZone(new SimpleTimeZone(0, "UTC"));
         Date time = format.parse(text);
         return NodeUtils.toJson((double) (time.getTime() / 1000.0));
       } catch (IllegalArgumentException e) {
@@ -857,7 +857,7 @@ public class BuiltinFunctions {
 
       String formatstr = NodeUtils.toString(arguments[1], false);
 
-      TimeZone zone = new SimpleTimeZone(SimpleTimeZone.UTC_TIME, "UTC");
+      TimeZone zone = new SimpleTimeZone(0, "UTC");
       if (arguments.length == 3) {
         String zonename = NodeUtils.toString(arguments[2], false);
         if (!zonenames.contains(zonename))

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -168,6 +168,16 @@
       "query" : "split(\"abc\", \",\")"
    },
    {
+      "input" : "1514764800",
+      "output" : "\"2018-01-01 00:00:00.000\"",
+      "query" : "format-time(., \"yyyy-MM-dd HH:mm:ss.SSS\")"
+   },
+   {
+      "output" : "1.5147648E9",
+      "input" : "\"2018-01-01 00:00:00.000\"",
+      "query" : "parse-time(., \"yyyy-MM-dd HH:mm:ss.SSS\")"
+   },
+   {
       "input" : "125641293.0",
       "output" : "\"1973-12-25 05:21:33CET\"",
       "query" : "format-time(., \"yyyy-MM-dd HH:mm:ssz\", \"CET\")"


### PR DESCRIPTION
SimpleDateFormat.UTC_TIME is used as a parameter for the startTimeMode and endTimeMode parameters, not the rawOffset parameter.