### PR TITLE
Add all() and any() functions

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -531,6 +531,18 @@ flatten([1, [2, [3, [4, []]]]]) => [1,2,3,4]
 flatten(null)                   => null
 ```
 
+### _all(array) -> boolean_
+
+True iff all elements of `array` evaluates to `true`
+
+Examples:
+
+```
+all([true, true, true])         => true
+all([true, true, false])        => false
+all(null)                       => false
+```
+
 <!-- TIME ===================================================================-->
 
 ## Time functions

--- a/functions.md
+++ b/functions.md
@@ -543,6 +543,18 @@ all([true, true, false])        => false
 all(null)                       => false
 ```
 
+### _any(array) -> boolean_
+
+True iff any elements of `array` evaluates to `true`.
+
+Examples:
+
+```
+any([false, false, false])      => false
+any([false, false, true])       => false
+any(null)                       => false
+```
+
 <!-- TIME ===================================================================-->
 
 ## Time functions

--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -98,6 +98,7 @@ public class BuiltinFunctions {
     functions.put("array", new BuiltinFunctions.Array());
     functions.put("is-array", new BuiltinFunctions.IsArray());
     functions.put("flatten", new BuiltinFunctions.Flatten());
+    functions.put("all", new BuiltinFunctions.All());
 
     // TIME
     functions.put("now", new BuiltinFunctions.Now());
@@ -544,6 +545,30 @@ public class BuiltinFunctions {
     }
   }
 
+  // ===== ALL
+
+  public static class All extends AbstractFunction {
+
+    public All() {
+      super("all", 1, 1);
+    }
+
+    public JsonNode call(JsonNode input, JsonNode[] arguments) {
+      JsonNode value = arguments[0];
+      if (value.isNull())
+        return BooleanNode.FALSE;
+      else if (!value.isArray())
+        throw new JsltException("all() cannot operate on " + value);
+
+
+      for (int ix = 0; ix < value.size(); ix++) {
+        JsonNode node = value.get(ix);
+        if (!NodeUtils.isTrue(node)) return BooleanNode.FALSE;
+      }
+      return BooleanNode.TRUE;
+    }
+
+  }
   // ===== STARTS-WITH
 
   public static class StartsWith extends AbstractFunction {

--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -99,6 +99,7 @@ public class BuiltinFunctions {
     functions.put("is-array", new BuiltinFunctions.IsArray());
     functions.put("flatten", new BuiltinFunctions.Flatten());
     functions.put("all", new BuiltinFunctions.All());
+    functions.put("any", new BuiltinFunctions.Any());
 
     // TIME
     functions.put("now", new BuiltinFunctions.Now());
@@ -569,6 +570,32 @@ public class BuiltinFunctions {
     }
 
   }
+
+  // ===== ANY
+
+  public static class Any extends AbstractFunction {
+
+    public Any() {
+      super("any", 1, 1);
+    }
+
+    public JsonNode call(JsonNode input, JsonNode[] arguments) {
+      JsonNode value = arguments[0];
+      if (value.isNull())
+        return BooleanNode.FALSE;
+      else if (!value.isArray())
+        throw new JsltException("any() cannot operate on " + value);
+
+
+      for (int ix = 0; ix < value.size(); ix++) {
+        JsonNode node = value.get(ix);
+        if (NodeUtils.isTrue(node)) return BooleanNode.TRUE;
+      }
+      return BooleanNode.FALSE;
+    }
+
+  }
+
   // ===== STARTS-WITH
 
   public static class StartsWith extends AbstractFunction {

--- a/src/test/java/com/schibsted/spt/data/jslt/QueryTest.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/QueryTest.java
@@ -55,7 +55,8 @@ public class QueryTest extends TestBase {
 
       JsonNode expected = mapper.readTree(output);
 
-      assertEquals("actual class " + actual.getClass() + ", expected class " + expected.getClass(), expected, actual);
+      assertEquals("actual class " + actual.getClass() + ", expected class " + expected.getClass() +
+          " in  query " + this.query, expected, actual);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
@@ -63,6 +63,11 @@ public class ToStringTest extends TestBase {
   }
 
   @Test
+  public void testFunctionAll() {
+    verify("all([true, false])", "all([true,false])");
+  }
+
+  @Test
   public void testFunction2() {
     verify("number(\"22\", null)", "number(\"22\", null)");
   }

--- a/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
@@ -63,8 +63,13 @@ public class ToStringTest extends TestBase {
   }
 
   @Test
-  public void testFunctionAll() {
+  public void testFunctionAny() {
     verify("all([true, false])", "all([true,false])");
+  }
+
+  @Test
+  public void testFunctionAll() {
+    verify("any([true, false])", "any([true,false])");
   }
 
   @Test

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -791,6 +791,21 @@
       "query" : "all(null)",
       "input" : "{}",
       "output" : "false"
+   },
+   {
+      "query" : "any([false, false])",
+      "input" : "{}",
+      "output" : "false"
+   },
+   {
+      "query" : "any([false, true])",
+      "input" : "{}",
+      "output" : "true"
+   },
+   {
+      "query" : "any(null)",
+      "input" : "{}",
+      "output" : "false"
    }
 ]
 }

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -776,6 +776,21 @@
       "query" : "flatten(null)",
       "input" : "{}",
       "output" : "null"
+   },
+   {
+      "query" : "all([true, true])",
+      "input" : "{}",
+      "output" : "true"
+   },
+   {
+      "query" : "all([true, false])",
+      "input" : "{}",
+      "output" : "false"
+   },
+   {
+      "query" : "all(null)",
+      "input" : "{}",
+      "output" : "false"
    }
 ]
 }


### PR DESCRIPTION
This allows for expressions like `all([for (.object.cause) is-object(.)])` to express checks for all members of an array. 