### PR TITLE
Add randint(bound) built-in function

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -188,6 +188,16 @@ Examples:
 random() => 0.24712712424
 ```
 
+### _randint(bound) -> integer_
+
+Returns a random integer between 0 and _bound-1_, where _bound_ is a positive integer.
+
+Examples:
+
+```
+randint(10) => 7
+```
+
 <!-- STRING =================================================================-->
 
 ## String functions

--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -70,6 +70,7 @@ public class BuiltinFunctions {
     functions.put("floor", new BuiltinFunctions.Floor());
     functions.put("ceiling", new BuiltinFunctions.Ceiling());
     functions.put("random", new BuiltinFunctions.Random());
+    functions.put("randint", new BuiltinFunctions.RandInt());
 
     // STRING
     functions.put("is-string", new BuiltinFunctions.IsString());
@@ -208,6 +209,26 @@ public class BuiltinFunctions {
 
     public JsonNode call(JsonNode input, JsonNode[] arguments) {
       return new DoubleNode(random.nextDouble());
+    }
+  }
+
+  // ===== RANDINT
+
+  public static class RandInt extends AbstractFunction {
+    private static java.util.Random random = new java.util.Random();
+
+    public RandInt() { super("randint", 1, 1); }
+
+    public JsonNode call(JsonNode input, JsonNode[] arguments) {
+      if (!arguments[0].isInt())
+        throw new JsltException("randint() expects a positive integer as argument");
+
+      Integer bound = arguments[0].asInt();
+
+      if (bound <= 0)
+        throw new JsltException("randint() expects a positive integer as argument");
+
+      return new IntNode(random.nextInt(bound));
     }
   }
 

--- a/src/test/java/com/schibsted/spt/data/jslt/StaticTests.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/StaticTests.java
@@ -68,6 +68,24 @@ public class StaticTests extends TestBase {
   }
 
   @Test
+  public void testRandIntFunction() {
+    try {
+      JsonNode context = mapper.readTree("{}");
+
+      Expression expr = Parser.compileString("randint(10)");
+
+      for (int ix = 0; ix < 10; ix++) {
+        JsonNode actual = expr.apply(context);
+        assertTrue(actual.isNumber());
+        double value = actual.intValue();
+        assertTrue(value >=0 && value < 10);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
   public void testJavaExtensionFunction() {
     check("{}", "test()", "42", Collections.EMPTY_MAP,
           Collections.singleton(new TestFunction()));


### PR DESCRIPTION
This function, `randint(bound)` allows to generate random integers between `0` (inclusive) and `bound` (exclusive). I left out the `randint()` (i.e., parameterless) implementation because I wasn't sure what would the expected behaviour be (i.e., drawing a positive or signed integer).