### PR TITLE
Add hash-code(string) built-in function

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -318,13 +318,15 @@ uppercase(null)     => null
 
 ### _sha256-hex(string) -> string_
 
-Generates the SHA256 hash of the input string.
+Generates a string with the hexadecimal representation of the SHA256 hash of the input string.
 
 Examples:
 
 ```
-sha256("foo") => "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
-sha256(null)  => null
+sha256-hex("foo") => "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+sha256-hex("42")  => "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
+sha256-hex(42)    => "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
+sha256-hex(null)  => null
 ```
 
 ### _starts-with(tested, prefix) -> boolean_

--- a/functions.md
+++ b/functions.md
@@ -316,17 +316,15 @@ uppercase("abcæøå") => "ABCÆØÅ"
 uppercase(null)     => null
 ```
 
-### _hash-code(string) -> integer_
+### _sha256(string) -> string_
 
-Converts the input string into a hash code. The hash code is computed
-as:
-_s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]_
+Generates the SHA256 hash of the input string.
 
 Examples:
 
 ```
-hash-code("foo") => 101574
-hash-code(null)  => null
+sha256("foo") => "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+sha256(null)  => null
 ```
 
 ### _starts-with(tested, prefix) -> boolean_

--- a/functions.md
+++ b/functions.md
@@ -316,6 +316,19 @@ uppercase("abcæøå") => "ABCÆØÅ"
 uppercase(null)     => null
 ```
 
+### hash-code(string) -> integer_
+
+Converts the input string into a hash code. The hash code is computed
+as:
+     * s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1] *
+
+Examples:
+
+```
+hash-code("foo") => 101574
+hash-code(null)  => null
+```
+
 ### _starts-with(tested, prefix) -> boolean_
 
 True iff the `tested` string starts with `prefix`.

--- a/functions.md
+++ b/functions.md
@@ -316,11 +316,11 @@ uppercase("abcæøå") => "ABCÆØÅ"
 uppercase(null)     => null
 ```
 
-### hash-code(string) -> integer_
+### _hash-code(string) -> integer_
 
 Converts the input string into a hash code. The hash code is computed
 as:
-     * s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1] *
+_s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]_
 
 Examples:
 

--- a/functions.md
+++ b/functions.md
@@ -316,7 +316,7 @@ uppercase("abcæøå") => "ABCÆØÅ"
 uppercase(null)     => null
 ```
 
-### _sha256(string) -> string_
+### _sha256-hex(string) -> string_
 
 Generates the SHA256 hash of the input string.
 

--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -82,7 +82,7 @@ public class BuiltinFunctions {
     functions.put("join", new BuiltinFunctions.Join());
     functions.put("lowercase", new BuiltinFunctions.Lowercase());
     functions.put("uppercase", new BuiltinFunctions.Uppercase());
-    functions.put("sha256", new BuiltinFunctions.Sha256());
+    functions.put("sha256-hex", new BuiltinFunctions.Sha256());
     functions.put("starts-with", new BuiltinFunctions.StartsWith());
     functions.put("ends-with", new BuiltinFunctions.EndsWith());
     functions.put("from-json", new BuiltinFunctions.FromJson());
@@ -383,9 +383,15 @@ public class BuiltinFunctions {
   // ===== SHA256
 
   public static class Sha256 extends AbstractFunction {
+    final MessageDigest messageDigest;
 
     public Sha256() {
-      super("sha256", 1, 1);
+      super("sha256-hex", 1, 1);
+      try {
+        messageDigest = MessageDigest.getInstance("SHA-256");
+      } catch (NoSuchAlgorithmException e) {
+        throw new JsltException("sha256-hex: could not find sha256 algorithm " + e);
+      }
     }
 
     public JsonNode call(JsonNode input, JsonNode[] arguments) {
@@ -394,13 +400,8 @@ public class BuiltinFunctions {
         return arguments[0]; // null
 
       String message = NodeUtils.toString(arguments[0], false);
-      MessageDigest messageDigest;
-      try {
-        messageDigest = MessageDigest.getInstance("SHA-256");
-      } catch (NoSuchAlgorithmException e) {
-        throw new InternalError(e);
-      }
-      byte[] bytes = messageDigest.digest(message.getBytes(UTF_8));
+
+      byte[] bytes = this.messageDigest.digest(message.getBytes(UTF_8));
       String string = DatatypeConverter.printHexBinary(bytes).toLowerCase();
 
       return new TextNode(string);

--- a/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -80,6 +80,7 @@ public class BuiltinFunctions {
     functions.put("join", new BuiltinFunctions.Join());
     functions.put("lowercase", new BuiltinFunctions.Lowercase());
     functions.put("uppercase", new BuiltinFunctions.Uppercase());
+    functions.put("hash-code", new BuiltinFunctions.HashCode());
     functions.put("starts-with", new BuiltinFunctions.StartsWith());
     functions.put("ends-with", new BuiltinFunctions.EndsWith());
     functions.put("from-json", new BuiltinFunctions.FromJson());
@@ -373,6 +374,24 @@ public class BuiltinFunctions {
 
       String string = NodeUtils.toString(arguments[0], false);
       return new TextNode(string.toUpperCase());
+    }
+  }
+
+  // ===== HASH-CODE
+
+  public static class HashCode extends AbstractFunction {
+
+    public HashCode() {
+      super("hash-code", 1, 1);
+    }
+
+    public JsonNode call(JsonNode input, JsonNode[] arguments) {
+      // if input string is missing then we're doing nothing
+      if (arguments[0].isNull())
+        return arguments[0]; // null
+
+      String string = NodeUtils.toString(arguments[0], false);
+      return new IntNode(string.hashCode());
     }
   }
 

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -625,7 +625,7 @@
    {
       "input" : "{}",
       "output" : "\"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\"",
-      "query" : "sha256(\"foo\")"
+      "query" : "sha256-hex(\"foo\")"
    },
    {
       "output" : "false",

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -628,6 +628,16 @@
       "query" : "sha256-hex(\"foo\")"
    },
    {
+      "input" : "{}",
+      "output" : "true",
+      "query" : "sha256-hex(\"42\") == sha256-hex(42)"
+   },
+   {
+      "input" : "{}",
+      "output" : "null",
+      "query" : "sha256-hex(null)"
+   },
+   {
       "output" : "false",
       "input" : "{}",
       "query" : "boolean(\"\")"

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -623,6 +623,11 @@
       "query" : "uppercase(\"foo\")"
    },
    {
+      "input" : "{}",
+      "output" : "101574",
+      "query" : "hash-code(\"foo\")"
+   },
+   {
       "output" : "false",
       "input" : "{}",
       "query" : "boolean(\"\")"

--- a/src/test/resources/function-tests.json
+++ b/src/test/resources/function-tests.json
@@ -624,8 +624,8 @@
    },
    {
       "input" : "{}",
-      "output" : "101574",
-      "query" : "hash-code(\"foo\")"
+      "output" : "\"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae\"",
+      "query" : "sha256(\"foo\")"
    },
    {
       "output" : "false",


### PR DESCRIPTION
The `hash-code(string)` function uses the native java hashCode to generate a hash (int) for a given string.