### PR TITLE
WIP: Experimental VM-based implementation

### DIFF
--- a/src/main/java/com/schibsted/spt/data/jslt/vm/JsonBinaryParser.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/vm/JsonBinaryParser.java
@@ -1,0 +1,119 @@
+
+package com.schibsted.spt.data.jslt.vm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonToken.*;
+
+public class JsonBinaryParser {
+  private static final JsonFactory jsonFactory = new JsonFactory();
+
+  public static void main(String[] argv) throws IOException {
+    ResourceManager mgr = new ResourceManager();
+
+    JsonBuffer buf = parse(new File(argv[0]), mgr);
+    buf.streamTo(jsonFactory.createJsonGenerator(System.out), mgr);
+    System.out.println();
+    System.out.println();
+
+    int keyid = mgr.getStringId("@id");
+    System.out.println("keyid: " + keyid);
+    System.out.println(buf.getKey(keyid | JsonBuffer.JS_STRING, 0));
+
+    System.out.println();
+    JsonVm vm = new JsonVm(mgr);
+    int result = vm.execute(buf);
+
+    if ((result & JsonBuffer.JS_OBJECT) == JsonBuffer.JS_OBJECT) {
+      JsonBuffer out = vm.getBuffer(vm.getBufferIndex(result));
+      out.dump();
+      JsonGenerator gen = jsonFactory.createJsonGenerator(System.out);
+      System.out.println("out offset: " + vm.getBufferOffset(result));
+      out.streamTo(gen, vm.getBufferOffset(result), mgr);
+      gen.flush();
+      System.out.println();
+    } else
+      System.out.println("UH OH");
+  }
+
+  public static JsonBuffer parse(File input, ResourceManager mgr) throws IOException {
+    return parse(jsonFactory.createParser(input), mgr);
+  }
+
+  public static JsonBuffer parse(String json, ResourceManager mgr) throws IOException {
+    return parse(jsonFactory.createParser(json), mgr);
+  }
+
+  public static JsonBuffer parse(JsonParser parser, ResourceManager mgr) throws IOException {
+
+    JsonBuffer buf = new JsonBuffer();
+
+    JsonToken token = parser.nextToken();
+    while (token != null) {
+      switch (token) {
+      case START_OBJECT:
+        buf.startObject();
+        break;
+      case END_OBJECT:
+        buf.endObject();
+        break;
+      case FIELD_NAME:
+      case VALUE_STRING:
+        buf.addString(mgr.getStringId(parser.getText()));
+        break;
+      case VALUE_NUMBER_INT:
+        boolean ok = false;
+        try {
+          int value = parser.getIntValue();
+          if (value <= JsonBuffer.RM_INTEGER) {
+            buf.addInlineInt(value);
+            ok = true;
+          }
+        } catch (JsonParseException e) {
+        }
+
+        if (!ok)
+          buf.addBigInt(mgr.getBigIntId(parser.getBigIntegerValue()));
+
+        break;
+      case START_ARRAY:
+        buf.startArray();
+        break;
+      case END_ARRAY:
+        buf.endArray();
+        break;
+      case VALUE_TRUE:
+        buf.addBoolean(true);
+        break;
+      case VALUE_FALSE:
+        buf.addBoolean(false);
+        break;
+      case VALUE_NULL:
+        buf.addNull();
+        break;
+      case VALUE_NUMBER_FLOAT:
+        buf.addDecimal(parser.getFloatValue());
+        break;
+      default:
+        throw new RuntimeException("Unknown token: " + token);
+      }
+
+      token = parser.nextToken();
+    }
+
+    return buf;
+  }
+
+  public static void output(OutputStream out, JsonVm vm, int ref, ResourceManager mgr) throws IOException {
+    JsonBuffer buf = vm.getBuffer(vm.getBufferIndex(ref));
+    JsonGenerator gen = jsonFactory.createJsonGenerator(out);
+    buf.streamTo(gen, vm.getBufferOffset(ref), mgr);
+  }
+}

--- a/src/main/java/com/schibsted/spt/data/jslt/vm/JsonBuffer.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/vm/JsonBuffer.java
@@ -1,0 +1,213 @@
+
+package com.schibsted.spt.data.jslt.vm;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+public class JsonBuffer {
+  public static final int JS_INTEGER = 0x80000000; // 1xxxxxxxx
+  public static final int JS_DECIMAL = 0x40000000; // 01xxxxxxx
+  public static final int JS_STRING  = 0x20000000; // 001xxxxxx
+  public static final int JS_OBJECT  = 0x10000000; // 0001xxxxx
+  public static final int JS_ARRAY   = 0x08000000; // 00001xxxx
+  public static final int JS_BIGINT  = 0x04000000; // 000001xxx
+  public static final int JS_BOOLEAN = 0x01000000; // 00000001x
+  public static final int JS_NULL    = 0x00700000; // 000000001
+
+  public static final int RM_INTEGER = 0x7FFFFFFF;
+  public static final int RM_STRING  = 0x1FFFFFFF;
+  public static final int RM_OBJECT  = 0x0FFFFFFF;
+  public static final int RM_ARRAY   = 0x07FFFFFF;
+  public static final int RM_BIGINT  = 0x03FFFFFF;
+  public static final int RM_BOOLEAN = 0x00FFFFFF;
+
+  private int[] data;
+  private int end;
+
+  private int[] stack;
+  private int stack_ix;
+
+  public JsonBuffer() {
+    this.data = new int[8];
+    this.end = 0;
+
+    this.stack = new int[8];
+    this.stack_ix = 0;
+  }
+
+  // === BUILD JSON
+
+  public void startObject() {
+    expandIfNecessary();
+    stack[stack_ix++] = end;
+    data[end++] = JS_OBJECT;
+  }
+
+  public void endObject() {
+    // end is where the next thing, whatever it is, will be
+    // our object is on top of the stack, so get reference from there
+    // then AND in reference to next thing
+    data[stack[--stack_ix]] = JS_OBJECT | end;
+  }
+
+  public void addString(int id) {
+    expandIfNecessary();
+    data[end++] = JS_STRING | id;
+  }
+
+  public void addInlineInt(int value) {
+    expandIfNecessary();
+    data[end++] = JS_INTEGER | value;
+  }
+
+  public void addBigInt(int id) {
+    expandIfNecessary();
+    data[end++] = JS_BIGINT | id;
+  }
+
+  public void startArray() {
+    expandIfNecessary();
+    stack[stack_ix++] = end;
+    data[end++] = JS_ARRAY;
+  }
+
+  public void endArray() {
+    // end is where the next thing, whatever it is, will be
+    // our array is on top of the stack, so get reference from there
+    // then AND in reference to next thing
+    data[stack[--stack_ix]] = JS_ARRAY | end;
+  }
+
+  public void addBoolean(boolean b) {
+    expandIfNecessary();
+    data[end++] = JS_BOOLEAN | (b ? 1 : 0);
+  }
+
+  public void addRawValue(int value) {
+    expandIfNecessary();
+    data[end++] = value;
+  }
+
+  public void addNull() {
+    expandIfNecessary();
+    data[end++] = JS_NULL;
+  }
+
+  // FIXME: this is broken
+  public void addDecimal(float number) {
+    expandIfNecessary();
+    data[end++] = JS_DECIMAL | ((int) number);
+  }
+
+  private void expandIfNecessary() {
+    if (end == data.length) {
+      int[] newData = new int[data.length * 2];
+      System.arraycopy(data, 0, newData, 0, data.length);
+      data = newData;
+    }
+  }
+
+  // ===== OUTPUT TO JSON
+
+  public void streamTo(JsonGenerator gen, ResourceManager mgr) throws IOException {
+    streamTo(gen, 0, mgr);
+    gen.flush();
+  }
+
+  public int streamTo(JsonGenerator gen, int ix, ResourceManager mgr) throws IOException {
+    if ((data[ix] & JS_INTEGER) == JS_INTEGER) {
+      gen.writeNumber(data[ix++] & RM_INTEGER);
+    } else if ((data[ix] & JS_STRING) == JS_STRING) {
+      gen.writeString(mgr.getString(data[ix++] & RM_STRING));
+    } else if ((data[ix] & JS_OBJECT) == JS_OBJECT) {
+      int end = data[ix] & RM_OBJECT;
+      gen.writeStartObject();
+      ix++;
+
+      while (ix < end) {
+        gen.writeFieldName(mgr.getString(data[ix] & RM_STRING));
+        ix = streamTo(gen, ix + 1, mgr);
+      }
+      gen.writeEndObject();
+    } else if ((data[ix] & JS_ARRAY) == JS_ARRAY) {
+      gen.writeStartArray();
+      ix++;
+
+      int end = data[ix] & RM_ARRAY;
+      while (ix < end)
+        ix = streamTo(gen, ix, mgr);
+
+      gen.writeEndArray();
+    } else if ((data[ix] & JS_BIGINT) == JS_BIGINT) {
+      gen.writeNumber(mgr.getBigInt(data[ix++] & RM_BIGINT));
+    } else if ((data[ix] & JS_BOOLEAN) == JS_BOOLEAN) {
+      gen.writeBoolean((data[ix++] & JS_BOOLEAN) == 1);
+    } else if (data[ix] == JS_NULL) {
+      gen.writeNull();
+      ix++;
+    } else
+      throw new RuntimeException("Unknown object type (" + ix + "): " + data[ix]);
+
+    return ix;
+  }
+
+  // ===== QUERY
+
+  public int getOffset() {
+    return end;
+  }
+
+  public int getValueAt(int offset) {
+    return data[offset];
+  }
+
+  // key is (JS_INTEGER | id) of the key string we seek.
+  // ix is the offset of the object start
+  // return value is ... what, exactly?
+  public int getKey(int key, int ix) {
+    int end = data[ix] & RM_OBJECT;
+    ix++; // step over the start object marker
+
+    while (ix < end && data[ix] != key) {
+      int value = data[ix+1];
+      if ((value & JS_OBJECT) == JS_OBJECT) {
+        ix = value & RM_OBJECT;
+      } else if ((value & JS_ARRAY) == JS_ARRAY) {
+        ix = value & RM_ARRAY;
+      } else {
+        ix += 2; // it's an inline value, so just step over
+      }
+    }
+
+    if (data[ix] == key) {
+      int value = data[ix+1];
+      if ((value & JS_OBJECT) == JS_OBJECT)
+        return JS_OBJECT | (ix+1); // caller will add buffer ix
+      else if ((value & JS_ARRAY) == JS_ARRAY)
+        return JS_ARRAY | (ix+1);  // caller will add buffer ix
+      else
+        return data[ix+1]; // literals we can just return
+    } else
+      return JS_NULL;
+  }
+
+  // true iff object or array
+  public static boolean isContainer(int value) {
+    return (((value & JS_OBJECT) == JS_OBJECT) ||
+            ((value & JS_ARRAY) == JS_ARRAY));
+  }
+
+  // ===== DUMP
+
+  public void dump() {
+    System.out.println("===== buffer dump start =====");
+    for (int ix = 0; ix < end; ix++) {
+      System.out.println("buf[" + ix + "] = " + data[ix]);
+    }
+    System.out.println("===== buffer dump end =====");
+  }
+}

--- a/src/main/java/com/schibsted/spt/data/jslt/vm/JsonVm.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/vm/JsonVm.java
@@ -1,0 +1,160 @@
+
+package com.schibsted.spt.data.jslt.vm;
+
+/**
+ * Created every time we need to execute a query. Lives only for the
+ * lifetime of that query.
+ */
+public class JsonVm {
+  // passed to constructor
+  private ResourceManager mgr;
+  private int[] bytecode;
+
+  // internals
+  private JsonBuffer[] buffers;
+  private int buffers_ptr; // points to current buffer
+  private int[] stack;
+  private int stack_ptr; // points to current value
+
+  private int context_buf; // points to the buffer that is the context object
+  private int context_off; // gives the offset of the context obj within buffer
+
+  // variable slots?
+  // function list?
+
+  // opcodes
+  public static final int START_BUF = 0;
+  public static final int START_OBJ = 1;
+  public static final int GET_KEY   = 2;
+  public static final int PUSH_CTX  = 3;
+  public static final int STOP      = 4;
+  public static final int END_OBJ   = 5;
+  public static final int SET_KEY   = 6;
+
+  // object tag is 0001xxxxx... that means 28 bits remain. inside
+  // JsonBuffer all of those are used for the offset to the next
+  // value.  here one byte refers to the buffer, and the remaining 20
+  // bits are the offset within the buffer.
+  //
+  // tag = y, buffer ptr = x, buffer offset = z ->
+  // yyyyxxxxxxxxzzzzzzzzzzzzzzzzzzzz
+  //
+  // public static final int JS_OBJECT  = 0x10000000;
+  //
+  public static final int JS_OBJ_BUFPTR_MASK = 0x0FF00000; // get buf ptr
+  public static final int JS_OBJ_BUFOFF_MASK = 0x000FFFFF; // get buf offset
+
+  public JsonVm(ResourceManager mgr) {
+    this.mgr = mgr;
+
+    this.buffers = new JsonBuffer[10];
+    this.buffers_ptr = -1; // no current buffer
+
+    this.stack = new int[128];
+    this.stack_ptr = -1; // nothing on stack
+
+    this.bytecode = new int[]{
+      START_BUF, 0,
+      START_OBJ, 0,
+      PUSH_CTX, 0,
+      GET_KEY, mgr.getStringId("@id"),
+      SET_KEY, mgr.getStringId("event_id"),
+      PUSH_CTX, 0,
+      GET_KEY, mgr.getStringId("@type"),
+      SET_KEY, mgr.getStringId("event_type"),
+      PUSH_CTX, 0,
+      GET_KEY, mgr.getStringId("actor"),
+      GET_KEY, mgr.getStringId("spt:userId"),
+      SET_KEY, mgr.getStringId("user_id"),
+      END_OBJ, 0,
+      STOP, 0
+    };
+  }
+
+  public int execute(JsonBuffer input) {
+    this.buffers_ptr = -1; // no current buffer
+    this.stack_ptr = -1; // nothing on stack
+
+    buffers[++buffers_ptr] = input; // input is always in buffer 0
+    context_buf = 0; // point to the input
+    context_off = 0; // point to the top-level value in input
+
+    int pc = 0;
+    while (bytecode[pc] != STOP) {
+      switch (bytecode[pc]) {
+      case START_BUF:
+        buffers[++buffers_ptr] = new JsonBuffer();
+        break;
+
+      case START_OBJ:
+        int offset = buffers[buffers_ptr].getOffset();
+        stack[++stack_ptr] = makeObjectReference(buffers_ptr, offset);
+        buffers[buffers_ptr].startObject();
+        break;
+
+      case PUSH_CTX:
+        stack[++stack_ptr] = makeObjectReference(context_buf, context_off);
+        break;
+
+      case GET_KEY:
+        // takes object from top of stack, replaces with result
+
+        if ((JsonBuffer.JS_OBJECT & stack[stack_ptr]) == JsonBuffer.JS_OBJECT) {
+          int buffer_ix = getBufferIndex(stack[stack_ptr]);
+          int buffer_of = getBufferOffset(stack[stack_ptr]);
+          int key = bytecode[pc + 1] | JsonBuffer.JS_STRING;
+          stack[stack_ptr] = buffers[buffer_ix].getKey(key, buffer_of);
+
+          // if this is an object or array we need to add buffer index
+          if (JsonBuffer.isContainer(stack[stack_ptr]))
+            stack[stack_ptr] = (buffer_ix << 20) | stack[stack_ptr];
+
+        } else if (stack[stack_ptr] != JsonBuffer.JS_NULL)
+          throw new RuntimeException("BAD OBJECT");
+
+        break;
+
+      case SET_KEY:
+        // key value on top of stack, object reference below. consume value,
+        // but leave the object
+        int value = stack[stack_ptr--];
+        int buffer_ix = getBufferIndex(stack[stack_ptr]);
+        int buffer_of = getBufferOffset(stack[stack_ptr]);
+        int key = bytecode[pc + 1];
+
+        buffers[buffer_ix].addString(key); // first write the key
+        // FIXME: it's not necessarily a literal!!
+        buffers[buffer_ix].addRawValue(value);
+        break;
+
+      case END_OBJ:
+        buffers[buffers_ptr].endObject();
+        break;
+
+      default:
+        throw new RuntimeException("WHOA!");
+      }
+
+      pc += 2;
+    }
+
+    return stack[0];
+  }
+
+  public JsonBuffer getBuffer(int id) {
+    return buffers[id];
+  }
+
+  private static int makeObjectReference(int buffer_ptr, int buffer_off) {
+    // add together JS_OBJECT_TAG, buffer ptr, and buffer offset
+    return JsonBuffer.JS_OBJECT | buffer_off | (buffer_ptr << 20);
+  }
+
+  public static int getBufferIndex(int obj) {
+    return (obj & JS_OBJ_BUFPTR_MASK) >> 20;
+  }
+
+  public static int getBufferOffset(int obj) {
+    return (obj & JS_OBJ_BUFOFF_MASK);
+  }
+}

--- a/src/main/java/com/schibsted/spt/data/jslt/vm/ResourceManager.java
+++ b/src/main/java/com/schibsted/spt/data/jslt/vm/ResourceManager.java
@@ -1,0 +1,68 @@
+
+package com.schibsted.spt.data.jslt.vm;
+
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+public class ResourceManager {
+  private Map<String, Integer> reverseLexicon;
+  private String[] lexicon;
+
+  private Map<BigInteger, Integer> reverseBigInt;
+  private BigInteger[] bigInts;
+
+  public ResourceManager() {
+    this.lexicon = new String[1024];
+    this.reverseLexicon = new HashMap<>();
+    this.bigInts = new BigInteger[1024];
+    this.reverseBigInt = new HashMap<>();
+  }
+
+  public int getStringId(String str) {
+    Integer id = reverseLexicon.get(str);
+    if (id == null) {
+      id = new Integer(reverseLexicon.size());
+      if (lexicon.length == id)
+        expandLexicon();
+      reverseLexicon.put(str, id);
+      lexicon[id] = str;
+    }
+    return id;
+  }
+
+  public String getString(int id) {
+    return lexicon[id];
+  }
+
+  public int getBigIntId(BigInteger bigint) {
+    Integer id = reverseLexicon.get(bigint);
+    if (id == null) {
+      id = new Integer(reverseBigInt.size());
+      if (bigInts.length == id)
+        expandBigInts();
+      reverseBigInt.put(bigint, id);
+      bigInts[id] = bigint;
+    }
+    return id;
+  }
+
+  public BigInteger getBigInt(int id) {
+    return bigInts[id];
+  }
+
+  private void expandLexicon() {
+    String[] newLexicon = new String[lexicon.length * 2];
+    System.arraycopy(lexicon, 0, newLexicon, 0, lexicon.length);
+    lexicon = newLexicon;
+  }
+
+  private void expandBigInts() {
+    BigInteger[] newBigInts = new BigInteger[bigInts.length * 2];
+    System.arraycopy(bigInts, 0, newBigInts, 0, bigInts.length);
+    bigInts = newBigInts;
+  }
+}


### PR DESCRIPTION
This is an experiment to see if a VM that uses an efficient representation of JSON as an array of ints can be faster than the AST-based implementation that works on Jackson `JsonNode` objects.

So far, experiments indicate that object->object transforms can be about 40% faster.

This approach also has the benefit of being independent of Jackson. That is, the input no longer has to be parsed by Jackson, and it doesn't even really need to be JSON. Same with the output.

A lot more work would be needed to support all of JSLT on this VM, particularly as this branch doesn't even have an AST->bytecode compiler. Performance is likely to drop somewhat as more of JSLT is supported, but on the other hand there must be quite a lot of unexploited optimization opportunities in this code.

So work on this branch may continue in the future, as much for strategic reasons as for the pure performance gain.