### PR TITLE
Make utf-8 tests more portable

### DIFF
--- a/src/test/java/com/schibsted/spt/data/jslt/FileSystemResourceResolverTest.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/FileSystemResourceResolverTest.java
@@ -60,7 +60,7 @@ public class FileSystemResourceResolverTest {
     Expression e = parse("./src/test/resources/character-encoding-master.jslt", resolver);
 
     JsonNode result = e.apply(NullNode.instance);
-    assertEquals("Hei på deg", result.asText());
+    assertEquals("Hei p\u00e5 deg", result.asText());
   }
 
   private Expression parse(String resource, ResourceResolver resolver) throws IOException {


### PR DESCRIPTION
The tests used to fail in Windows as the character `å` in the .java files
was interpreted as `Ã¥`. By replacing å with the explicit \u00e5
make sures that it will be interpreted ok correctly no matter the encoding
of the .java files.