### PR TITLE
Make utf-8 tests more portable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ repositories {
   mavenCentral()
 }
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+
 dependencies {
   compile 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
 

--- a/src/test/java/com/schibsted/spt/data/jslt/FileSystemResourceResolverTest.java
+++ b/src/test/java/com/schibsted/spt/data/jslt/FileSystemResourceResolverTest.java
@@ -60,7 +60,7 @@ public class FileSystemResourceResolverTest {
     Expression e = parse("./src/test/resources/character-encoding-master.jslt", resolver);
 
     JsonNode result = e.apply(NullNode.instance);
-    assertEquals("Hei p\u00e5 deg", result.asText());
+    assertEquals("Hei på deg", result.asText());
   }
 
   private Expression parse(String resource, ResourceResolver resolver) throws IOException {


### PR DESCRIPTION
The tests used to fail in Windows as the character `å` in the .java files
was interpreted as `Ã¥`. `javac` was interpreting the UTF-8 encoded
files as WINDOWS-1252 encoded file.

By explicitly setting that UTF-8 encoding in the Gradle configurations
`compileJava` and `compileTestJava` we make sure that `javac` will
interpret all files as UTF-8 (which they already are).