### PR TITLE
fix Expression#toString for complex expressions

### DIFF
--- a/core/src/main/java/com/schibsted/spt/data/jslt/impl/AbstractOperator.java
+++ b/core/src/main/java/com/schibsted/spt/data/jslt/impl/AbstractOperator.java
@@ -75,6 +75,9 @@ public abstract class AbstractOperator extends AbstractNode {
   public abstract JsonNode perform(JsonNode v1, JsonNode v2);
 
   public String toString() {
-    return left.toString() + " " + operator + " " + right;
+    if (operator == "and" || operator == "or")
+      return "(" + left.toString() + " " + operator + " " + right + ")";
+    else
+      return left.toString() + " " + operator + " " + right;
   }
 }

--- a/core/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/ToStringTest.java
@@ -105,6 +105,11 @@ public class ToStringTest extends TestBase {
     verify("$foo", "$foo");
   }
 
+  @Test
+  public void testParenthesis() {
+    verify(".get1 == 1 and (.get1 == 1 or .get1 == 2)", "(.get1 == 1 and (.get1 == 1 or .get1 == 2))");
+  }
+
   // ----- UTILITIES
 
   private void verify(String input, String output) {


### PR DESCRIPTION
When compiling `.get1 == 1 and (.get1 == 1 or .get1 == 2)` it generates an `Expression` with a valid AST, however the `toString` representation is `.get1 == 1 and .get1 == 1 or .get1 == 2`.

I don’t expect the input string to be equal to the `toString` version of the resulting `Expression`, but they should be logically equivalent.