### PR TITLE
Add UUID provided function

### DIFF
--- a/core/src/test/java/com/schibsted/spt/data/jslt/buildinfunctions/UuidTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/buildinfunctions/UuidTest.java
@@ -1,0 +1,42 @@
+package com.schibsted.spt.data.jslt.buildinfunctions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schibsted.spt.data.jslt.Expression;
+import com.schibsted.spt.data.jslt.JsltException;
+import com.schibsted.spt.data.jslt.Parser;
+import com.schibsted.spt.data.jslt.TestBase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UuidTest extends TestBase {
+  private static ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void testUuidWithoutParameterMatchesRegex() throws JsonProcessingException {
+    Expression given = Parser.compileString("uuid()");
+    String actual = mapper.writeValueAsString(given.apply(null));
+
+    String uuidRegex = "^\"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\"$";
+    assertTrue(actual.matches(uuidRegex));
+  }
+
+  @Test
+  public void testUuidWithoutParameterGeneratesRandomValues() throws JsonProcessingException {
+    Expression given = Parser.compileString("{ \"uuid1\" : uuid(), \"uuid2\" : uuid() }");
+    JsonNode result = given.apply(null);
+    String actual1 = mapper.writeValueAsString(result.findValue("uuid1"));
+    String actual2 = mapper.writeValueAsString(result.findValue("uuid2"));
+
+    assertNotEquals(actual1, actual2);
+  }
+
+  @Test(expected = JsltException.class)
+  public void testUuidWithOneParameterRaisesJsltException() {
+    Expression given = Parser.compileString("uuid(123)");
+    given.apply(null);
+  }
+}

--- a/core/src/test/resources/function-tests.json
+++ b/core/src/test/resources/function-tests.json
@@ -1143,6 +1143,41 @@
       "output": "\"a\""
    },
    {
+      "query": "uuid(9223372036854775807, 9223372036854775807)",
+      "input" : "null",
+      "output": "\"7fffffff-ffff-1fff-bfff-ffffffffffff\""
+   },
+   {
+      "query": "uuid(-9223372036854775808, -9223372036854775808)",
+      "input" : "null",
+      "output": "\"80000000-0000-1000-8000-000000000000\""
+   },
+   {
+      "query": "uuid(0, 0)",
+      "input" : "null",
+      "output": "\"00000000-0000-1000-8000-000000000000\""
+   },
+   {
+      "query": "uuid(null, 9223372036854775807)",
+      "input" : "null",
+      "output": "\"00000000-0000-1000-bfff-ffffffffffff\""
+   },
+   {
+      "query": "uuid(9223372036854775807, null)",
+      "input" : "null",
+      "output": "\"7fffffff-ffff-1fff-8000-000000000000\""
+   },
+   {
+      "query": "uuid(1234567890, 1234567890)",
+      "input" : "null",
+      "output": "\"00000000-4996-102d-8000-0000499602d2\""
+   },
+   {
+      "query": "uuid(null, null)",
+      "input" : "null",
+      "output": "\"00000000-0000-0000-0000-000000000000\""
+   },
+   {
       "query": "min(1, 2)",
       "input" : "null",
       "output": "1"

--- a/functions.md
+++ b/functions.md
@@ -526,6 +526,22 @@ trim(false)        => "false"
 trim(null)         => null
 ```
 
+### _uuid(long, long) -> string_
+
+Generates a formatted UUID string with dashes.
+If no parameter are passed, a random UUID version 4 will be generated.
+If two parameter are passed, a UUID version 1 is generated based on two long values where the first parameter represents the MSB (most significant bytes) and the second parameter the LSB (least significant bytes) of the UUID.
+If both parameter are null a NIL UUID (00000000-0000-0000-0000-000000000000 is generated)
+
+Examples:
+
+```
+uuid()                       => "b02c39c0-6f8f-4250-97cd-78500af36e27"
+uuid(1234567890, 1234567890) => "00000000-4996-102d-8000-0000499602d2"
+uuid(0, 0)                   => "00000000-0000-1000-8000-000000000000"
+uuid(null, null)             => "00000000-0000-0000-0000-000000000000"
+```
+
 <!-- BOOLEAN ================================================================-->
 
 ## Boolean functions


### PR DESCRIPTION
added uuid build-in function
- tests are only present for call with both parameter, as the other calls don't return a deterministic value and the QueryTests expect a constant as expected value - tested manually (worked for all three constellations with none, one and two parameter), let me know if i should add an extra test, that validates against a regex
- MR is based on MR #251 & #252
- solves Issue #203