### PR TITLE
(dependency) - upgraded JUnit and jackson

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
-    id 'com.intershop.gradle.javacc' version '4.0.1'
+    id 'com.intershop.gradle.javacc' version '4.1.3'
     id 'java'
     id 'com.jfrog.artifactory'
     id 'maven-publish'
@@ -15,10 +15,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.1'
 }
 
 ext {
@@ -61,7 +61,7 @@ javacc {
 // ===========================================================================
 // Sonatype Maven central publishing
 
-task sourceJar(type: Jar) {
+tasks.register('sourceJar', Jar) {
     classifier "sources"
     from sourceSets.main.allJava
 }
@@ -80,7 +80,8 @@ javadoc {
     source = sourceSets.javadoc.allJava
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
     classifier "javadoc"
     from javadoc.destinationDir
 }

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -13,9 +13,9 @@ repositories {
 dependencies {
   implementation project(':core')
   implementation 'org.eclipse.jetty:jetty-server:9.4.45.v20220203'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 }
 
 group 'com.schibsted.spt.data'
-version '0.0.1'
+version '0.1.14'
 project.description 'JSLT demo playground implementation'

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@ This file is only here to enable the Github dependency graph.
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.17.1</version>
       <type>jar</type>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>
@@ -33,7 +33,7 @@ This file is only here to enable the Github dependency graph.
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.2</version>
+      <version>2.17.0</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Upgraded the dependencies in `pom.xml` and `build.gradle`.
Also followed the suggestion to re-write the deprecated `task` to `task.register`.

Closes #353