### PR TITLE
fix: #373 - Enhance identifier parsing to support Unicode characters

### DIFF
--- a/core/src/main/jjtree/jslt.jjt
+++ b/core/src/main/jjtree/jslt.jjt
@@ -69,13 +69,13 @@ TOKEN :
   < DEF: "def" > |
   < IMPORT: "import" > |
   < AS: "as" > |
-  < IDENT: (["A"-"Z"] | ["a"-"z"] | ["0"-"9"] | "_" | "-")+ > |
-  < PIDENT:
-    (["A"-"Z"] | ["a"-"z"] | ["0"-"9"] | "_" | "-")+
-    ":"
-    (["A"-"Z"] | ["a"-"z"] | ["0"-"9"] | "_" | "-")+
-  > |
-  < VARIABLE: "$" (["A"-"Z"] | ["a"-"z"] | ["0"-"9"] | "_" | "-")+ >
+    // Define a private token fragment for all valid identifier characters,
+    // including the common Latin Unicode letters.
+    < #IDENT_CHARS: ["A"-"Z", "a"-"z", "0"-"9", "_", "-", "\u00C0"-"\u00D6", "\u00D8"-"\u00F6", "\u00F8"-"\u017F"] > |
+
+  < IDENT: (<IDENT_CHARS>)+ > |
+  < PIDENT: (<IDENT_CHARS>)+ ":" (<IDENT_CHARS>)+ > |
+  < VARIABLE: "$" (<IDENT_CHARS>)+ >
 }
 
 // http://www.engr.mun.ca/~theo/JavaCC-FAQ/javacc-faq-moz.htm#tth_sEc3.15

--- a/core/src/main/jjtree/jslt.jjt
+++ b/core/src/main/jjtree/jslt.jjt
@@ -69,9 +69,7 @@ TOKEN :
   < DEF: "def" > |
   < IMPORT: "import" > |
   < AS: "as" > |
-    // Define a private token fragment for all valid identifier characters,
-    // including the common Latin Unicode letters.
-    < #IDENT_CHARS: ["A"-"Z", "a"-"z", "0"-"9", "_", "-", "\u00C0"-"\u00D6", "\u00D8"-"\u00F6", "\u00F8"-"\u017F"] > |
+  < #IDENT_CHARS: ["A"-"Z", "a"-"z", "0"-"9", "_", "-", "\u0080"-"\uffff"] > |
 
   < IDENT: (<IDENT_CHARS>)+ > |
   < PIDENT: (<IDENT_CHARS>)+ ":" (<IDENT_CHARS>)+ > |

--- a/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
@@ -374,24 +374,9 @@ public class TemplateTest extends TestBase {
 
   @Test
   public void testUnicodeIdentifierParsing() {
-    String input = """
-            {
-              "mypropé" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1",
-              "type" : "View"
-            }
-            """;
-    String jslt = """
-            {
-              "id" : .mypropé,
-              "type" : "Anonymized-View"
-            }
-            """;
-    String result = """
-            {
-              "id" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1",
-              "type" : "Anonymized-View"
-            }
-            """;
+    String input = " {\"mypropé\" : \"w23q7ca1-8729-24923-922b-1c0517ddffjf1\", \"type\" : \"View\"} ";
+    String jslt = "{\"id\" : .mypropé, \"type\" : \"Anonymized-View\"} ";
+    String result = "{\"id\" : \"w23q7ca1-8729-24923-922b-1c0517ddffjf1\",\"type\" : \"Anonymized-View\"} ";
     check(input, jslt, result);
   }
 

--- a/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
@@ -373,7 +373,7 @@ public class TemplateTest extends TestBase {
   }
 
   @Test
-  public void asciiCharParsing() {
+  public void testUnicodeIdentifierParsing() {
     String input = """
             {
               "mypropé" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1",
@@ -388,7 +388,7 @@ public class TemplateTest extends TestBase {
             """;
     String result = """
             {
-              "id" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1" ,
+              "id" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1",
               "type" : "Anonymized-View"
             }
             """;

--- a/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/TemplateTest.java
@@ -1,15 +1,7 @@
 
 package com.schibsted.spt.data.jslt;
 
-import java.io.IOException;
 import org.junit.Test;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.NullNode;
 
 /**
  * Test cases verifying templates.
@@ -378,6 +370,29 @@ public class TemplateTest extends TestBase {
     check(load("user-external.json"),
           load("user-external2cdp.jslt"),
           load("cdp.json"));
+  }
+
+  @Test
+  public void asciiCharParsing() {
+    String input = """
+            {
+              "mypropé" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1",
+              "type" : "View"
+            }
+            """;
+    String jslt = """
+            {
+              "id" : .mypropé,
+              "type" : "Anonymized-View"
+            }
+            """;
+    String result = """
+            {
+              "id" : "w23q7ca1-8729-24923-922b-1c0517ddffjf1" ,
+              "type" : "Anonymized-View"
+            }
+            """;
+    check(input, jslt, result);
   }
 
 }


### PR DESCRIPTION
This change will fix #373 by including Unicode characters in jslt.jjt , A supporting test method has also been included.