### PR TITLE
feat: add filter() macro for array filtering

### DIFF
--- a/core/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
+++ b/core/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java
@@ -138,6 +138,7 @@ public class BuiltinFunctions {
   public static Map<String, Macro> macros = new HashMap();
   static {
     macros.put("fallback", new BuiltinFunctions.Fallback());
+    macros.put("filter", new BuiltinFunctions.Filter());
   }
 
   private static abstract class AbstractMacro extends AbstractCallable implements Macro {
@@ -596,6 +597,33 @@ public class BuiltinFunctions {
           return value;
       }
       return NullNode.instance;
+    }
+  }
+
+  // ===== FILTER
+
+  public static class Filter extends AbstractMacro {
+
+    public Filter() {
+      super("filter", 2, 2);
+    }
+
+    public JsonNode call(Scope scope, JsonNode input,
+                         ExpressionNode[] parameters) {
+      JsonNode array = parameters[0].apply(scope, input);
+      if (array.isNull())
+        return NullNode.instance;
+      if (!array.isArray())
+        throw new JsltException("filter() argument is not an array: " + array);
+
+      ArrayNode result = NodeUtils.mapper.createArrayNode();
+      for (int ix = 0; ix < array.size(); ix++) {
+        JsonNode element = array.get(ix);
+        JsonNode test = parameters[1].apply(scope, element);
+        if (NodeUtils.isTrue(test))
+          result.add(element);
+      }
+      return result;
     }
   }
 

--- a/core/src/test/java/com/schibsted/spt/data/jslt/QueryErrorTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/QueryErrorTest.java
@@ -60,6 +60,7 @@ public class QueryErrorTest extends TestBase {
     List<Object[]> strings = new ArrayList();
     strings.addAll(loadTests("query-error-tests.json"));
     strings.addAll(loadTests("function-error-tests.json"));
+    strings.addAll(loadTests("filter-error-tests.json"));
     strings.addAll(loadTests("function-declaration-tests.yaml"));
     return strings;
   }

--- a/core/src/test/java/com/schibsted/spt/data/jslt/QueryTest.java
+++ b/core/src/test/java/com/schibsted/spt/data/jslt/QueryTest.java
@@ -67,6 +67,7 @@ public class QueryTest extends TestBase {
     strings.addAll(loadTests("query-tests.yaml"));
     strings.addAll(loadTests("function-tests.json"));
     strings.addAll(loadTests("experimental-tests.json"));
+    strings.addAll(loadTests("filter-tests.json"));
     strings.addAll(loadTests("function-declaration-tests.yaml"));
     return strings;
   }

--- a/core/src/test/resources/filter-error-tests.json
+++ b/core/src/test/resources/filter-error-tests.json
@@ -1,0 +1,11 @@
+{
+    "description" : "Error tests for the filter() macro.",
+    "tests" :
+[
+   {
+      "query" : "filter(42, .active)",
+      "input" : "{}",
+      "error" : "filter() argument is not an array"
+   }
+]
+}

--- a/core/src/test/resources/filter-tests.json
+++ b/core/src/test/resources/filter-tests.json
@@ -1,0 +1,36 @@
+{
+    "description" : "Tests for the filter() macro.",
+    "tests" :
+[
+   {
+      "query" : "filter([{\"a\":1,\"active\":true},{\"a\":2,\"active\":false}], .active)",
+      "input" : "{}",
+      "output" : "[{\"a\":1,\"active\":true}]"
+   },
+   {
+      "query" : "filter([1, 2, 3, 4, 5], . > 3)",
+      "input" : "{}",
+      "output" : "[4, 5]"
+   },
+   {
+      "query" : "filter(null, .active)",
+      "input" : "{}",
+      "output" : "null"
+   },
+   {
+      "query" : "filter([], .active)",
+      "input" : "{}",
+      "output" : "[]"
+   },
+   {
+      "query" : "[for (filter([{\"id\":1,\"ok\":true},{\"id\":2,\"ok\":false}], .ok)) .id]",
+      "input" : "{}",
+      "output" : "[1]"
+   },
+   {
+      "query" : "size(filter([{\"active\":true},{\"active\":false},{\"active\":true}], .active))",
+      "input" : "{}",
+      "output" : "2"
+   }
+]
+}

--- a/functions.md
+++ b/functions.md
@@ -58,6 +58,24 @@ if (not(is-array(.things)))
   error("'things' is not an array")
 ```
 
+### _filter(array, expr) -> array_
+
+Returns a new array containing only the elements of _array_ for which
+_expr_ evaluates to a truthy value. _expr_ is evaluated with each
+element as the context node (`.`).
+
+If _array_ is `null` the result is `null`. If _array_ is empty the
+result is `[]`.
+
+Examples:
+
+```
+filter([1, 2, 3, 4, 5], . > 3)                          => [4, 5]
+filter(.items, .active)                                  => [{...}, ...]
+size(filter(.items, .active))                            => 2
+[for (filter(.items, .active)) .id]                      => [...]
+```
+
 ### _fallback(arg1, arg2, ...) -> value_
 
 Returns the first argument that has a value. That is, the first


### PR DESCRIPTION

## Summary

Adds a built-in `filter(array, predicate)` macro that returns only the
elements of an array for which the predicate expression is truthy.

### Why a macro (not a function)?

The predicate must be re-evaluated with each element as the context
node (`.`). A regular function receives arguments already evaluated to
a single value, so the predicate would be lost. This is the same reason
`for` is a language construct and `fallback` is a macro.

### Behaviour

| Input | Result |
|---|---|
| `filter(null, expr)` | `null` |
| `filter([], expr)` | `[]` |
| `filter(nonArray, expr)` | `JsltException` |
| falsy predicate result | element excluded |

### Examples

```jslt
filter(.items, .active)
filter([1, 2, 3, 4, 5], . > 3)                  // => [4, 5]
size(filter(.items, .active))
[for (filter(.items, .active)) .id]

let active = filter(.items, .active)
{ "count": size($active), "ids": [for ($active) .id] }
```

## Changes

| File | Change |
|---|---|
| `core/src/main/java/com/schibsted/spt/data/jslt/impl/BuiltinFunctions.java` | `Filter` macro class + registered in `macros` map |
| `core/src/test/resources/filter-tests.json` | 6 happy-path test cases |
| `core/src/test/resources/filter-error-tests.json` | 1 error test case (non-array input) |
| `core/src/test/java/com/schibsted/spt/data/jslt/QueryTest.java` | Load `filter-tests.json` |
| `core/src/test/java/com/schibsted/spt/data/jslt/QueryErrorTest.java` | Load `filter-error-tests.json` |
| `functions.md` | Documented `filter()` alongside `fallback` |

## Implementation Details

`Filter` extends `AbstractMacro` (same base as `fallback`) with a fixed
arity of 2. At runtime:

1. Evaluates `parameters[0]` once to get the array
2. Returns `null` if the array is null; throws `JsltException` if not an array
3. For each element, evaluates `parameters[1]` with that element as the context node
4. Keeps elements where `NodeUtils.isTrue(result)` — consistent with how `for` handles its `if` clause

No grammar or parser changes were needed — macros are dispatched by name
via `ParseContext.getMacro()` in `ParserImpl.chainable2Expr()`, the same
mechanism used by `fallback`.

## Related

- Closes #227 — Filter object in an array and getting a value
- Ideas: `ideas/filter.md`, `ideas/for-filter.md`
