### PR TITLE
Document JavaScript port (jslt-js) in README; add it to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ things) some of the ways Schibsted uses JSLT.
 
 [Apache Camel JSLT component](https://camel.apache.org/components/latest/jslt-component.html).
 
+[JavaScript port](https://github.com/amkraev697642/jslt-js) for Node.js and browsers
+([npm](https://www.npmjs.com/package/jslt-js)). It passes all conformance
+fixtures and is the only full JavaScript implementation of this language as of Jul 2026.
+
 JSLT is also integrated in [Apache NiFi](https://nifi.apache.org/) [as a processor](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-jslt-nar/1.20.0/org.apache.nifi.processors.jslt.JSLTTransformJSON/index.html).
 
 [How Willhaben.at uses JSLT with Kafka Connect](https://tech.willhaben.at/kafka-connect-custom-single-message-transform-using-jslt-2fc57ae98395)

--- a/playground/README.md
+++ b/playground/README.md
@@ -22,9 +22,11 @@ right there.
 
 The playground page also offers **Run in JS**, which evaluates transforms
 entirely in the browser using
-[jslt-js](https://github.com/amkraev697642/jslt-js). This works without
-building or running the Java server — open the HTML via the server above, or
-host `lambda.html` on any static file server.
+[jslt-js](https://github.com/amkraev697642/jslt-js) loaded from
+[npm](https://www.npmjs.com/package/jslt-js) via unpkg (`@latest`, so each page
+load picks up the current published release). This works without building or
+running the Java server — open the HTML via the server above, or host
+`lambda.html` on any static file server (network required for unpkg).
 
 The **Run (Java server)** button still uses the original Java JSLT engine via
 POST (as on [garshol.priv.no/jslt-demo](http://www.garshol.priv.no/jslt-demo)).

--- a/playground/README.md
+++ b/playground/README.md
@@ -17,3 +17,14 @@ java -cp playground/build/libs/playground-0.0.1-all.jar no.priv.garshol.jslt.pla
 
 Then go to `http://localhost:9999/jslt` and you'll have the playground
 right there.
+
+## Run in JS (browser)
+
+The playground page also offers **Run in JS**, which evaluates transforms
+entirely in the browser using
+[jslt-js](https://github.com/amkraev697642/jslt-js). This works without
+building or running the Java server — open the HTML via the server above, or
+host `lambda.html` on any static file server.
+
+The **Run (Java server)** button still uses the original Java JSLT engine via
+POST (as on [garshol.priv.no/jslt-demo](http://www.garshol.priv.no/jslt-demo)).

--- a/playground/src/main/resources/lambda.html
+++ b/playground/src/main/resources/lambda.html
@@ -33,7 +33,7 @@
     margin-top: 48pt;
   }
 </style>
-<script src="https://unpkg.com/jslt-js@0.1.0/dist/jslt-bundle.js"></script>
+<script src="https://unpkg.com/jslt-js@0.1.2/dist/jslt-bundle.js"></script>
 <script>
 function setResult(text) {
   document.getElementById('result').firstChild.nodeValue = text;

--- a/playground/src/main/resources/lambda.html
+++ b/playground/src/main/resources/lambda.html
@@ -8,6 +8,11 @@
     text-decoration: none;
     display: inline-block;
     font-size: 16px;
+    margin-right: 8px;
+  }
+
+  .button-js {
+    background-color: #1976D2;
   }
 
   pre {
@@ -28,10 +33,14 @@
     margin-top: 48pt;
   }
 </style>
+<script src="https://unpkg.com/jslt-js@0.1.0/dist/jslt-bundle.js"></script>
 <script>
+function setResult(text) {
+  document.getElementById('result').firstChild.nodeValue = text;
+}
+
 function send() {
-  var out = document.getElementById('result');
-  out.firstChild.nodeValue = '...wait...';
+  setResult('...wait...');
 
   var input = document.getElementById('input').value
   var jslt = document.getElementById('jslt').value
@@ -45,11 +54,32 @@ function send() {
 
   http.onreadystatechange = function() {
     if (http.readyState == 4 && http.status == 200) {
-      var out = document.getElementById('result');
-      out.firstChild.nodeValue = http.responseText;
+      setResult(http.responseText);
     }
   }
   http.send(JSON.stringify(data));
+}
+
+function runInJs() {
+  setResult('...wait...');
+
+  if (typeof JSLT === 'undefined') {
+    setResult('jslt-js failed to load. Check your network connection.');
+    return;
+  }
+
+  try {
+    var inputJson = document.getElementById('input').value;
+    var jsltSource = document.getElementById('jslt').value;
+    var input = (inputJson.trim() === '')
+      ? JSLT.fromJS(null)
+      : JSLT.readTree(inputJson);
+    var expr = JSLT.compile(jsltSource, 'playground.jslt');
+    var result = JSLT.toJS(expr.applyInput(input));
+    setResult(JSON.stringify(result, null, 2));
+  } catch (e) {
+    setResult(e.stack || e.message || String(e));
+  }
 }
 </script>
 
@@ -62,6 +92,11 @@ transforms.
 Please <a href="https://github.com/schibsted/jslt/issues"
 >report any issues</a>.</p>
 
+<p><strong>Run in JS</strong> executes transforms in your browser via
+<a href="https://github.com/amkraev697642/jslt-js">jslt-js</a>
+(no Java server required). <strong>Run (Java server)</strong> uses the
+original playground backend when available.</p>
+
 <h2>Result</h2>
 
 <pre id="result">
@@ -70,7 +105,10 @@ Please <a href="https://github.com/schibsted/jslt/issues"
 
 </pre>
 
-<p><input type=submit value="Run!" class=button onclick="send()">
+<p>
+  <input type=submit value="Run in JS" class="button button-js" onclick="runInJs()">
+  <input type=submit value="Run (Java server)" class=button onclick="send()">
+</p>
 
 <h2>JSLT</h2>
 

--- a/playground/src/main/resources/lambda.html
+++ b/playground/src/main/resources/lambda.html
@@ -33,7 +33,7 @@
     margin-top: 48pt;
   }
 </style>
-<script src="https://unpkg.com/jslt-js@0.1.2/dist/jslt-bundle.js"></script>
+<script src="https://unpkg.com/jslt-js@latest/dist/jslt-bundle.js"></script>
 <script>
 function setResult(text) {
   document.getElementById('result').firstChild.nodeValue = text;


### PR DESCRIPTION
## Summary

- **README:** link to [jslt-js](https://github.com/amkraev697642/jslt-js) (npm, Node + browser, passes upstream conformance tests).
- **Playground:** adds **Run in JS**, **Run (Java server)** unchanged.

## Notes

- No changes to core Java engine.
- Playground tested locally with Java 11